### PR TITLE
EDS migration fixes: home page subtitle and sidebar navigation configs

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -13,6 +13,7 @@
         - [InDesign API](/dom/api/index.md)
 
 - subPages:
+    - [Overview](introduction/index.md)
     - Essentials header
     - [Programming languages](/introduction/essentials/tech-stack/index.md)
     - [Developer Tools](/introduction/essentials/dev-tools/index.md)
@@ -23,6 +24,7 @@
         - [Options for Distribution](/introduction/next-steps/distribution/distribution-options/index.md)
     - Applications header
     - [InDesign Server](/introduction/applications/ids.md)
+    - [Overview](scripts/index.md)
     - Scripts header
     - [Getting started](/scripts/getting-started/index.md)
     - [Concepts](/scripts/concepts/index.md)
@@ -35,6 +37,7 @@
         - [InDesign Server Object Model](/scripts/tutorials/ids-object-model/index.md)
         - [Tips & tricks](/scripts/tutorials/tips-tricks/index.md)
     - [Advanced topics](/scripts/advanced/index.md)
+    - [Overview](plugins/index.md)
     - Plugins header
     - [Getting started](/plugins/getting-started/index.md)
     - [Concepts](/plugins/concepts/index.md)
@@ -50,6 +53,7 @@
         - [Communicate with other plugins](/plugins/tutorials/inter-plugin-comm/index.md)
         - [Modularizing code](/plugins/tutorials/importing-modules/index.md)
     - [Advanced topics](/plugins/advanced/index.md)
+    - [Overview](resources/index.md)
     - Resources header
     - [Fundamentals](/resources/fundamentals/index.md)
         - [APIs](/resources/fundamentals/apis/index.md)
@@ -80,6 +84,7 @@
         - [Right-to-left](/resources/recipes/rtl/index.md)
         - [Flyout Menus](/resources/recipes/flyout-menu/index.md)
         - [Persistent Storage Migration](/resources/recipes/persistent-storage-migration/index.md)
+    - [Overview](reference/uxp-api/index.md)
     - UXP API reference header
     - [JavaScript Reference](/reference/uxp-api/reference-js/index.md)
         - [Global Members](/reference/uxp-api/reference-js/global-members/index.md)
@@ -380,6 +385,7 @@
         - [Spectrum Widgets to SWC](/reference/uxp-api/reference-spectrum/spectrum-widgets-to-swc-mapping/index.md)
         - [FAQs](/reference/uxp-api/reference-spectrum/faqs/index.md)
     - [Known Issues](/reference/uxp-api/known-issues.md)
+    - [Overview](dom/api/index.md)
     - Indesign DOM reference header
     - [AddPageOptions](/dom/api/a/add-page-options/index.md)
     - [AdjustLayoutPreference](/dom/api/a/adjust-layout-preference/index.md)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -12,7 +12,7 @@ contributors:
 
 # UXP for Adobe InDesign
 
-Welcome to the world of UXP (**U**nified E**x**tensibility **P**latform) in Adobe InDesign!
+Welcome to the world of UXP (Unified Extensibility Platform) in Adobe InDesign!
 
 <Resources slots="heading, links"/>
 


### PR DESCRIPTION
## What this PR fixes

- **Sidebar / next-prev navigation**: Pages under `/plugins/`, `/scripts/`, `/resources/`, `/reference/uxp-api/`, `/dom/api/`, and `/introduction/` were showing the wrong sidebar (and broken next/prev arrows). Per the [SideNav spec](https://developer-stage.adobe.com/dev-docs-reference/blocks/sidenav/), first-level `subPages` entries need to match TopNav sections. Added 6 `[Overview](section/index.md)` entries in `config.md`.
## How to verify after merge

1. Run the **Staging** workflow on `eds-migration`
2. Check:
   - Subtitle should read "Welcome to the world of UXP (Unified Extensibility Platform)..." with no broken spacing
   - Sidebar on each section page should show an "Overview" entry at the top
   - Next/prev arrows at page bottom should follow sidebar order