### PR TITLE
Fix EDS lint errors

### DIFF
--- a/src/pages/contributors.json
+++ b/src/pages/contributors.json
@@ -5468,10 +5468,11 @@
     {
       "page": "/introduction/next-steps/distribution/packaging/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/42615528?v=4"
       ],
-      "lastUpdated": "6/3/2026"
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/introduction/next-steps/script-and-plugin/",
@@ -5599,8 +5600,10 @@
     },
     {
       "page": "/reference/uxp-api/changelog3-p",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/reference/uxp-api/known-issues",
@@ -6284,8 +6287,10 @@
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/crypto",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/crypto/",
@@ -6299,8 +6304,10 @@
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/data-storage/local-storage",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/data-storage/session-storage",
@@ -6679,8 +6686,10 @@
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/image-blob",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/image-blob/",
@@ -6689,8 +6698,10 @@
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/path",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/reference/uxp-api/reference-js/global-members/path/",
@@ -6764,8 +6775,10 @@
     },
     {
       "page": "/reference/uxp-api/reference-js/modules/uxp/",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/reference/uxp-api/reference-js/modules/uxp/entry-points/",
@@ -7223,8 +7236,10 @@
     },
     {
       "page": "/resources/recipes/host-info/",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/resources/recipes/html-elements/",
@@ -7239,10 +7254,11 @@
     {
       "page": "/resources/recipes/indesign-events/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/42615528?v=4"
       ],
-      "lastUpdated": "6/3/2026"
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/resources/recipes/indesign-menus/",
@@ -7251,8 +7267,10 @@
     },
     {
       "page": "/resources/recipes/launch-process/",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/resources/recipes/network/",
@@ -7280,8 +7298,10 @@
     },
     {
       "page": "/resources/recipes/storage/",
-      "avatars": [],
-      "lastUpdated": "5/11/2026"
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/31863114?v=4"
+      ],
+      "lastUpdated": "8/17/2026"
     },
     {
       "page": "/resources/recipes/tbd-drag-n-drop",

--- a/src/pages/introduction/next-steps/distribution/packaging/index.md
+++ b/src/pages/introduction/next-steps/distribution/packaging/index.md
@@ -31,7 +31,7 @@ UXP plugins are distributed in the form of a `.ccx` file. Under the hood, this i
 ### Packaging a plugin
 Taking your plugin code and packaging it has never been easier.
 
-Using the [UXP Developer Tool](../../devtool/index.md), choose `Package` from the Actions menu (the ellipsis on the right side of the Developer Tool window, on the same line as your plugin name):
+Using the [UXP Developer Tool](../../../essentials/dev-tools/index.md), choose `Package` from the Actions menu (the ellipsis on the right side of the Developer Tool window, on the same line as your plugin name):
 
 ![Package Menu](../images/udt-package-menu.png)
 

--- a/src/pages/reference/uxp-api/changelog3-p.md
+++ b/src/pages/reference/uxp-api/changelog3-p.md
@@ -71,7 +71,7 @@ index_desc: Changelog in UXP version
 
 ## UXP v7.3.0
 ### New
-- [GUID](reference-js/modules/uxp/user-information/user-info.md) for uniquely identifying a Creative Cloud User (Currently Supported only in `Photoshop`).
+- [GUID](reference-js/modules/uxp/user-information/index.md) for uniquely identifying a Creative Cloud User (Currently Supported only in `Photoshop`).
 - Multipart `FormData` support in [Request](reference-js/global-members/data-transfers/request.md) and [Response](reference-js/global-members/data-transfers/response.md) for `fetch`
 - [FormData](reference-js/global-members/data-transfers/form-data.md) now supports the following APIs
     - delete()
@@ -105,7 +105,7 @@ Plugin actions are surfaced based on the 'Status' of your plugin in the Develope
 
 ## UXP v7.2.0
 ### New
-- Adobe [Extensibility Metadata Platform (XMP)](reference-js/modules/uxp/xmp/getting-started/xmp.md) support
+- Adobe [Extensibility Metadata Platform (XMP)](reference-js/modules/uxp/xmp/getting-started/index.md) support
 - [pointer-events: none](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) `CSS` property
 - Support for `pseudoElement` in [getComputedStyle(element, pseudoElement)](reference-js/global-members/html-dom/get-computed-style.md) API
 
@@ -179,7 +179,7 @@ html {
     - [prompt()](reference-js/global-members/html-dom/prompt.md)
     - [confirm()](reference-js/global-members/html-dom/confirm.md)
 - Support for [pipeThrough](reference-js/global-members/streams/readable-stream.md#pipeThroughtransform,-options) and [tee](reference-js/global-members/streams/readable-stream.md#tee) in ReadableStream](./reference-js/Global%20Members/Streams/ReadableStream.md). Refer to [Streams](reference-js/global-members/streams/index.md) for more details
-- [ImageBlob](reference-js/global-members/image-blob/image-blob.md) to render an uncompressed image buffer in UXP
+- [ImageBlob](reference-js/global-members/image-blob/index.md) to render an uncompressed image buffer in UXP
 
 ### Changed
 - [HTMLVideoElement](reference-js/global-members/html-elements/html-video-element.md): 'metadata' is the default value for `preload` attribute
@@ -197,7 +197,7 @@ html {
 
 ### New
 - [WebView](reference-js/global-members/html-elements/html-web-view-element.md) for anels
-- [Path Module APIs](reference-js/global-members/path/path.md)
+- [Path Module APIs](reference-js/global-members/path/index.md)
 - UXP Scripts can run fsapi with full access in localFileSystem
 
 ### Bugs Fixes
@@ -220,7 +220,7 @@ html {
 ### New
 - [Blob](reference-js/global-members/data-transfers/blob.md) APIs.
 - Blob support in Fetch API.
-- [Crypto APIs](reference-js/global-members/crypto/crypto.md)
+- [Crypto APIs](reference-js/global-members/crypto/index.md)
 - UXP Developer Tools v1.7.0 has supports for Debugging UXP Scripts in Photoshop and InDesign, refer [here](https://developer.adobe.com/photoshop/uxp/2022/scripting/getting-started/) for more details
 - UXP Developer Tools has new templates in the Create Plugin Dialog. This includes examples for using WebView and Multiple Menus in a Plugin. For more details on Webview refer [HTMLWebViewElement](reference-js/global-members/html-elements/html-web-view-element.md) module under `Global Members/HTML Elements` in JavaScript Reference
 

--- a/src/pages/reference/uxp-api/reference-js/global-members/crypto.md
+++ b/src/pages/reference/uxp-api/reference-js/global-members/crypto.md
@@ -5,4 +5,4 @@ description: UXP Crypto API reference for generating random values and UUIDs.
 
 # Crypto
 
-See [Crypto API](crypto/crypto.md) for full documentation.
+See [Crypto API](crypto/index.md) for full documentation.

--- a/src/pages/reference/uxp-api/reference-js/global-members/data-storage/local-storage.md
+++ b/src/pages/reference/uxp-api/reference-js/global-members/data-storage/local-storage.md
@@ -5,7 +5,7 @@ This data is technically persistent, but can be cleared in a variety of ways,
 so you should not store data using localStorage that you cannot otherwise reconstruct.
 <InlineAlert variant="warning" slots="text"/>
 
-Do not store passwords or other secure forms of data using `localStorage`. Instead, use [storage.secureStorage](/reference/uxp-api/reference-js/modules/uxp/key-value-storage/secure-storage.md)
+Do not store passwords or other secure forms of data using `localStorage`. Instead, use [storage.secureStorage](/reference/uxp-api/reference-js/modules/uxp/key-value-storage/index.md)
 
 
 

--- a/src/pages/reference/uxp-api/reference-js/global-members/image-blob.md
+++ b/src/pages/reference/uxp-api/reference-js/global-members/image-blob.md
@@ -5,4 +5,4 @@ description: UXP ImageBlob API reference for image data handling.
 
 # ImageBlob
 
-See [ImageBlob API](image-blob/image-blob.md) for full documentation.
+See [ImageBlob API](image-blob/index.md) for full documentation.

--- a/src/pages/reference/uxp-api/reference-js/global-members/path.md
+++ b/src/pages/reference/uxp-api/reference-js/global-members/path.md
@@ -5,4 +5,4 @@ description: UXP Path module reference for working with file and directory paths
 
 # Path
 
-See [Path API](path/path.md) for full documentation.
+See [Path API](path/index.md) for full documentation.

--- a/src/pages/reference/uxp-api/reference-js/modules/uxp/index.md
+++ b/src/pages/reference/uxp-api/reference-js/modules/uxp/index.md
@@ -6,5 +6,5 @@
 * [Plugin Manager](plugin-manager/index.md)
 * [User Information](user-information/index.md)
 * [Versions](versions/index.md)
-* [XMP](xmp/getting-started/xmp.md)
+* [XMP](xmp/getting-started/index.md)
 * [shell](shell/index.md)

--- a/src/pages/resources/recipes/host-info/index.md
+++ b/src/pages/resources/recipes/host-info/index.md
@@ -40,7 +40,7 @@ Application: InDesign v18.5.0 powered by uxp-7.1.0
 
 
 ## Reference material
-- [Host](/reference/uxp-api/reference-js/modules/uxp/host-information/host.md) APIs
-- [Versions](/reference/uxp-api/reference-js/modules/uxp/versions/versions.md) APIs
-- [OS](/reference/uxp-api/reference-js/modules/os/os.md) APIs
+- [Host](/reference/uxp-api/reference-js/modules/uxp/host-information/index.md) APIs
+- [Versions](/reference/uxp-api/reference-js/modules/uxp/versions/index.md) APIs
+- [OS](/reference/uxp-api/reference-js/modules/os/index.md) APIs
 

--- a/src/pages/resources/recipes/indesign-events/index.md
+++ b/src/pages/resources/recipes/indesign-events/index.md
@@ -12,7 +12,7 @@ InDesign emits standard application and document events, such as opening a file,
 
 **You can see the sample scripts in order of complexity, starting with very simple scripts and building toward more complex operations.**
 
-*Learn how to create, install, and run a script with [Adobe InDesign UXP Scripting Tutorial](../../guides/getting-started/index.md).*
+*Learn how to create, install, and run a script with [Adobe InDesign UXP Scripting Tutorial](../../../scripts/getting-started/index.md).*
 
 ## Understanding Event Scripting
 

--- a/src/pages/resources/recipes/launch-process/index.md
+++ b/src/pages/resources/recipes/launch-process/index.md
@@ -105,5 +105,5 @@ async function foo() {
 
 
 ## Reference material
-- [Shell API](/reference/uxp-api/reference-js/modules/uxp/shell/shell.md)
+- [Shell API](/reference/uxp-api/reference-js/modules/uxp/shell/index.md)
 

--- a/src/pages/resources/recipes/storage/index.md
+++ b/src/pages/resources/recipes/storage/index.md
@@ -56,4 +56,4 @@ await storage.getItem('key');
 ## Reference material
 - [Local Storage](/reference/uxp-api/reference-js/global-members/data-storage/local-storage.md)
 - [Session Storage](/reference/uxp-api/reference-js/global-members/data-storage/session-storage.md)
-- [Secure Storage](/reference/uxp-api/reference-js/modules/uxp/key-value-storage/secure-storage.md)
+- [Secure Storage](/reference/uxp-api/reference-js/modules/uxp/key-value-storage/index.md)


### PR DESCRIPTION
## Description

Post-migration, several reference pages moved their content into `index.md` but retained links pointing to the old flat filenames, such as `os/os.md`, `shell/shell.md`, and `crypto/crypto.md`.

This PR updates all 17 missing-file lint errors across the changelog, reference stub pages, and recipe pages to point to the correct `index.md` targets.

It also fixes a DevTools link that pointed to a directory that does not exist in this repository, redirecting it to the actual DevTools landing page.

## Related Issue

N/A

## Motivation and Context

`npm run lint` was failing with 17 fatal missing-file errors, which was blocking clean EDS deployments.

These broken links are a result of the EDS migration, where per-page content was moved into `index.md` files within the corresponding folders. For example:

* `crypto/crypto.md` → `crypto/index.md`
* `os/os.md` → `os/index.md`
* `shell/shell.md` → `shell/index.md`

Without these fixes, the links would remain unresolved and result in dead links once published.

## How Has This Been Tested?

Ran `npm run lint` before and after the changes:

* **Before:** 1,464 files / 17 errors / 1,575 warnings
* **After:** 1,464 files / 0 errors / 1579 warning

## Screenshots

N/A

## Types of Changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

* [ ] I have signed the Adobe CLA.
* [x] My code follows the code style of this project.
* [ ] My change requires a documentation update.
* [ ] I have updated the documentation accordingly.
* [ ] I have read the CONTRIBUTING guidelines.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests pass.
