### PR TITLE
Add site-wide banner for Adobe Developers Live 2026

### DIFF
--- a/src/pages/adp-site-metadata.json
+++ b/src/pages/adp-site-metadata.json
@@ -1,1 +1,1 @@
-{"total":4,"offset":0,"limit":4,"data":[{"key":"contributors","value":"src/pages/contributors.json"},{"key":"get-credentials","value":null},{"key":"site-wide-banner","value":null},{"key":"code-playground","value":null}],":type":"sheet"}
+{"total":4,"offset":0,"limit":4,"data":[{"key":"contributors","value":"src/pages/contributors.json"},{"key":"get-credentials","value":null},{"key":"site-wide-banner","value":"src/pages/site-wide-banner.json"},{"key":"code-playground","value":null}],":type":"sheet"}

--- a/src/pages/site-wide-banner.json
+++ b/src/pages/site-wide-banner.json
@@ -1,0 +1,16 @@
+{
+  "total": 1,
+  "offset": 0,
+  "limit": 1,
+  "data": [
+    {
+      "bgColor": "info",
+      "icon": "info",
+      "text": ["Code. Connect. Build What's Next. Adobe Developers Live 2026"],
+      "button": "Get your free ticket",
+      "buttonLink": "https://events.ringcentral.com/events/adobe-developers-live-2026-code-connect-build-whats-next?utm_source=Dev-Site%20Banner%20(developer.adobe.com)&utm_campaign=Save%20the%20date",
+      "isClose": true
+    }
+  ],
+  ":type": "sheet"
+}


### PR DESCRIPTION
## Description
Enables the site-wide banner by wiring `adp-site-metadata.json` to a new `site-wide-banner.json`. The banner promotes Adobe Developers Live 2026 with a "Get your free ticket" call-to-action link and is user-dismissible.

## Related Issue
N/A

## Motivation and Context
Adobe Developers Live 2026 needs site-wide promotion across Adobe developer documentation sites. This adds a dismissible info banner to the UXP Premiere Pro docs site, so visitors see the event announcement and registration link.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.